### PR TITLE
Fix borrow_shares_to_asset_amount to return integer amount instead of decimal amount

### DIFF
--- a/algofipy/lending/v2/market.py
+++ b/algofipy/lending/v2/market.py
@@ -221,11 +221,10 @@ class Market:
 
         if amount == 0:
             return AssetAmount(0, 0)
-        raw_underlying_amount = amount * self.underlying_borrowed / self.borrow_share_circulation
-        underlying_amount = raw_underlying_amount / 10**self.lending_client.algofi_client.assets[self.underlying_asset_id].decimals
+        raw_underlying_amount = int(amount * self.underlying_borrowed // self.borrow_share_circulation)
         usd_amount = self.underlying_to_usd(raw_underlying_amount)
-        return AssetAmount(underlying_amount, usd_amount)
-    
+        return AssetAmount(raw_underlying_amount, usd_amount)
+
     def underlying_to_b_asset(self, amount):
         """Convert underlying asset amount to b asset amount.
 


### PR DESCRIPTION
In this [commit](https://github.com/Algofiorg/algofi-python-sdk/commit/749e4e16cacb24b45624d19e95403e576812df69), when you updated `b_asset_to_asset_amount` to return the raw underlying integer amount instead of decimal, I think you forgot to also update `borrow_shares_to_asset_amount`, which still returns a decimal. It's kinda confusing that the collateral method returns an int while the borrow method returns a decimal.